### PR TITLE
Added line number parsing from filepath strings

### DIFF
--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -41,14 +41,24 @@ export class OpenFileFromText
 			return;
 
 		let p = FileOperations.getAbsoluteFromRelativePath(iWord, this.editor.document.fileName);
+		let lineNumber = 0;
+		let filepath = p;
+		//Check for :filenumber
+		if (p.indexOf(":") > -1) {
+			let parts = p.split(":");
+			filepath = parts[0];
+			lineNumber = parseInt(parts[1]);
+		}
 
-		if( existsSync(p) )
-		{
-			vscode.workspace.openTextDocument(p).then((iDoc) => {
-				if( iDoc !== undefined )
-				{
+		if (existsSync(filepath)) {
+			vscode.workspace.openTextDocument(filepath).then((iDoc) => {
+				if (iDoc !== undefined) {
 					vscode.window.showTextDocument(iDoc).then((iEditor) => {
-
+						if (lineNumber) {
+							let range = this.editor.document.lineAt(lineNumber - 1).range;
+							this.editor.selection = new vscode.Selection(range.start, range.end);
+							this.editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+						}
 					});
 				}
 			});

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -41,23 +41,16 @@ export class OpenFileFromText
 			return;
 
 		let p = FileOperations.getAbsoluteFromRelativePath(iWord, this.editor.document.fileName);
-		let lineNumber = 0;
-		let filepath = p;
-		//Check for :filenumber
-		if (p.indexOf(":") > -1) {
-			let parts = p.split(":");
-			filepath = parts[0];
-			lineNumber = parseInt(parts[1]);
-		}
+		let fileAndLine = TextOperations.getPathAndLineNumber(p)
 
-		if (existsSync(filepath)) {
-			vscode.workspace.openTextDocument(filepath).then((iDoc) => {
+		if (existsSync(fileAndLine.file)) {
+			vscode.workspace.openTextDocument(fileAndLine.file).then((iDoc) => {
 				if (iDoc !== undefined) {
 					vscode.window.showTextDocument(iDoc).then((iEditor) => {
-						if (lineNumber) {
-							let range = this.editor.document.lineAt(lineNumber - 1).range;
-							this.editor.selection = new vscode.Selection(range.start, range.end);
-							this.editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+						if (fileAndLine.line) {
+							let range = iEditor.document.lineAt(fileAndLine.line - 1).range;
+							iEditor.selection = new vscode.Selection(range.start, range.end);
+							iEditor.revealRange(range, vscode.TextEditorRevealType.InCenter);
 						}
 					});
 				}

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -41,7 +41,20 @@ export class TextOperations
 		}
 		return "";
 	}
-
+	public static getPathAndLineNumber(iWord:string): any
+	{
+		let fileAndLine = {
+			file: iWord,
+			line: -1
+		};
+		
+		if (fileAndLine.file.indexOf(":") > -1) {
+			const parts = fileAndLine.file.split(":");
+			fileAndLine.file = parts[0];
+			fileAndLine.line = parseInt(parts[1]);
+		}
+		return fileAndLine;
+	}
 	public static getWordBetweenBounds(iText: string, iPos:vscode.Position, iBounds?:RegExp): string
 	{
 		let bounds: RegExp = new RegExp("[\\s\\\"\\\'\\>\\<#]");


### PR DESCRIPTION
Thank you for writing this extension. For a project I'm currently working with type logs that have the line number appended to the file path. I'd like to load these files at the specified line.

For example
```
array_fill /Users/alex/projects/app/laravel/routing/router.php:587
Laravel\Routing\Route::post /Users/alex/projects/app/bundles/webform/routes.php:9
```

Feel free to suggest any changes.