### PR TITLE
Added some great features to deduce most paths   :-)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,6 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-		"typescript.tsdk": "./node_modules/typescript/lib",
-		"vsicons.presets.angular": false // we want to use the TS server from our node_modules folder to control its version
-	}
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "vsicons.presets.angular": false // we want to use the TS server from our node_modules folder to control its version
+}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
                 },
                 "seito-openfile.searchSubFoldersOfWorkspaceFolders": {
                     "type": "string",
-                    "default": "@(lib*|src|app|class*|module*|inc*|vendor?(s)|public)",
+                    "default": "@(lib*|lib*/*|src|src/*|app|app/*|class*|class*/*|module*|inc*|vendor|vendor/*|public)",
                     "description": "Pattern of sub-folders under workspace folder(s) to be searched at second last, for relative paths.  For syntax reference glob/minimatch"
                 },
                 "seito-openfile.searchPaths": {

--- a/package.json
+++ b/package.json
@@ -66,12 +66,15 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "typescript": "^2.4.0",
-        "vscode": "^1.14.0"
+        "typescript": "^2.0.3",
+        "vscode": "^1.0.0",
+        "mocha": "^2.3.3",
+        "@types/node": "^6.0.40",
+        "@types/mocha": "^2.2.32"
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.6.0",
     "publisher": "Fr43nk",
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.15.0"
     },
     "categories": [
         "Other"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
             "properties": {
                 "seito-openfile.wordbound": {
                     "type": "string",
-                    "default": "[\\s\\\"\\'\\>\\<#]",
+                    "default": "[\\s\\\"\\'\\>\\<#;]",
                     "description": "The RegExp to define the bound of the path string"
                 },
                 "seito-openfile.extensions": {

--- a/package.json
+++ b/package.json
@@ -61,15 +61,33 @@
                 "seito-openfile.extraExtensionsForTypes": {
                     "type": "object",
                     "default": {
-                        "js": ["jsx"],
-                        "jsx": ["js"]
+                        "js": [
+                            "jsx"
+                        ],
+                        "jsx": [
+                            "js"
+                        ]
                     },
                     "description": "Known suffixes to look for when file string has no suffix, according to current document's type. (suffix match is relative to current document's parent folders only)"
                 },
                 "seito-openfile.searchSubFoldersOfWorkspaceFolders": {
-                    "type": "string",
-                    "default": "@(lib*|lib*/*|src|src/*|app|app/*|class*|class*/*|module*|inc*|vendor|vendor/*|public)",
-                    "description": "Pattern of sub-folders under workspace folder(s) to be searched at second last, for relative paths.  For syntax reference glob/minimatch"
+                    "type": "array",
+                    "default": [
+                        "lib*/",
+                        "lib*/*/",
+                        "src/",
+                        "src/*/",
+                        "app/",
+                        "app/*/",
+                        "class?(es)/",
+                        "class?(es)/*/",
+                        "module?(s)/",
+                        "inc*/",
+                        "vendor?(s)/",
+                        "vendor?(s)/*/",
+                        "public/"
+                    ],
+                    "description": "Patterns of sub-folders under workspace folder(s) to be searched at second last, for relative paths.  For syntax reference glob-all/minimatch"
                 },
                 "seito-openfile.searchPaths": {
                     "type": "array",
@@ -92,7 +110,7 @@
         "@types/mocha": "^2.2.32"
     },
     "dependencies": {
-        "glob": "^7.1.2",
+        "glob-all": "^3.1.0",
         "true-case-path": "^1.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -55,12 +55,26 @@
                 },
                 "seito-openfile.extensions": {
                     "type": "array",
-                    "default": [
-                        "scss",
-                        "js",
-                        "jsx"
-                    ],
-                    "description": "Known suffixes to look for when file string has no suffix"
+                    "default": [],
+                    "description": "Known suffixes to look for when file string has no suffix (Deprecated. Default to search with current document's suffix if path in text has no extension)"
+                },
+                "seito-openfile.extraExtensionsForTypes": {
+                    "type": "object",
+                    "default": {
+                        "js": ["jsx"],
+                        "jsx": ["js"]
+                    },
+                    "description": "Known suffixes to look for when file string has no suffix, according to current document's type. (suffix match is relative to current document's parent folders only)"
+                },
+                "seito-openfile.searchSubFoldersOfWorkspaceFolders": {
+                    "type": "string",
+                    "default": "@(lib*|src|app|class*|module*|inc*|vendor?(s)|public)",
+                    "description": "Pattern of sub-folders under workspace folder(s) to be searched at second last, for relative paths.  For syntax reference glob/minimatch"
+                },
+                "seito-openfile.searchPaths": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Paths to be added to search at last, for relative paths"
                 }
             }
         }
@@ -76,5 +90,9 @@
         "mocha": "^2.3.3",
         "@types/node": "^6.0.40",
         "@types/mocha": "^2.2.32"
+    },
+    "dependencies": {
+        "glob": "^7.1.2",
+        "true-case-path": "^1.0.0"
     }
 }

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from 'vscode';
 import { dirname, extname, join, isAbsolute, basename } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, lstatSync } from 'fs';
 import { ConfigHandler } from '../configuration/confighandler';
 import { TextOperations } from '../common/textoperations';
 import { FileOperations } from '../common/fileoperations';
@@ -61,7 +61,7 @@ export class OpenFileFromText {
 
 		// First, try relative to current document's folder, or absolute path, or relative to "~"
 		let p = FileOperations.getAbsoluteFromRelativePath(inputPath, basePath, true);
-		if (existsSync(p))
+		if (existsSync(p) && lstatSync(p).isFile())
 			return p;
 
 		let isHomePath = inputPath[0] === "~";

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -38,11 +38,12 @@ export class OpenFileFromText {
 				reject("Something went wrong");
 
 			let fileAndLine = TextOperations.getPathAndLineNumber(iWord);
-			let p = FileOperations.getAbsoluteFromRelativePath(fileAndLine.file, this.editor.document.fileName);
+			let currentDocFileName = this.editor ? this.editor.document.fileName : '';
+			let p = FileOperations.getAbsoluteFromRelativePath(fileAndLine.file, currentDocFileName);
 			if (!existsSync(p)) {
 				let extensions = ConfigHandler.Instance.Configuration.Extensions;
 				for (let extension of extensions) {
-					p = FileOperations.getAbsolutePathFromFuzzyPath(fileAndLine.file, this.editor.document.fileName, extension);
+					p = FileOperations.getAbsolutePathFromFuzzyPath(fileAndLine.file, currentDocFileName, extension);
 					if (p != "") {
 						break;
 					}

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -27,8 +27,11 @@ export class OpenFileFromText {
 	public execute() {
 		for (let i: number = 0; i < this.editor.selections.length; i++) {
 			let word = this.getWordRange(this.editor.selections[i]);
-			this.openDocument(word);
-			console.log("Execute command", word);
+			this.openDocument(word).then(path => {
+				console.log("Execute command", word + ': Path found:', path);
+			}).catch(error => {
+				console.log("Execute command", word + ':', error);
+			});
 		}
 	}
 
@@ -58,10 +61,16 @@ export class OpenFileFromText {
 								let range = iEditor.document.lineAt(fileAndLine.line - 1).range;
 								iEditor.selection = new vscode.Selection(range.start, range.end);
 								iEditor.revealRange(range, vscode.TextEditorRevealType.InCenter);
-								resolve("");
+								resolve(p + ":" + fileAndLine.line);
+							} else {
+								resolve(p);
 							}
 						});
+					} else {
+						reject("Something went wrong with openTextDocument"); // impossible?
 					}
+				}, (reason: Error) => {
+					reject("Cannot open file: " + reason.message);
 				});
 			}
 			else {

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -129,7 +129,7 @@ export class OpenFileFromText {
 		let workspaceFolders = [];
 		if (isWithinAWorkspaceFolder)
 			workspaceFolders.push(currentWorkspaceFolderObj);
-		workspaceFolders = this.mergeDeduplicate(vscode.workspace.workspaceFolders);
+		workspaceFolders = this.mergeDeduplicate(vscode.workspace.workspaceFolders || []);
 		for (let workspaceFolderObj of workspaceFolders) {
 			let workspaceFolder = workspaceFolderObj.uri.fsPath;
 

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -105,7 +105,7 @@ export class OpenFileFromText {
 				return;
 
 			// From now on, treat even '/path/to/something' as relative path.  Thus, cut the leading slash/backslash
-			if (inputPath.match(/^[\/\\]/) {
+			if (inputPath.match(/^[\/\\]/)) {
 				inputPath = inputPath.substr(1);
 			}
 		}

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -7,7 +7,7 @@ import { ConfigHandler } from '../configuration/confighandler';
 import { TextOperations } from '../common/textoperations';
 import { FileOperations } from '../common/fileoperations';
 import { isArray } from 'util';
-var glob = require('glob');
+var glob = require('glob-all');
 var trueCasePathSync = require('true-case-path');
 
 

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -51,10 +51,13 @@ export class OpenFileFromText {
 	 */
 	public resolvePath(inputPath: string): string {
 		let debug = (...args) => {
-			// console.debug(...args);		// un-comment this to debug
+			// console.log(...args);		// un-comment this to debug
 		};
 		let currentDocFileName = this.editor ? this.editor.document.fileName : '';
 		let basePath = dirname(currentDocFileName);
+
+		// Normalize \ to / in the file string (\ not work for existsSync on linux-like), to support e.g. "use namespace\Class;" with path path/to/class/namespace/Class.php in PHP.
+		inputPath = inputPath.replace(/\\/g, '/');
 
 		// First, try relative to current document's folder, or absolute path, or relative to "~"
 		let p = FileOperations.getAbsoluteFromRelativePath(inputPath, basePath, true);

--- a/src/common/fileoperations.ts
+++ b/src/common/fileoperations.ts
@@ -11,7 +11,7 @@ export class FileOperations
 {
 	public static getAbsoluteFromRelativePath(iPath:string, iCurrPath:string): string
 	{
-		if( iPath === undefined || iPath === "" || iCurrPath === undefined || iCurrPath === "" )
+		if( iPath === undefined || iPath === "" || iCurrPath === undefined )
 			return "";
 
 		try
@@ -23,6 +23,8 @@ export class FileOperations
 			}
 			else if( isAbsolute(iPath) )
 				return join(iPath);
+			else if( iCurrPath === "" ) // fault tolerant: only fail when not absolute or relative-to-home path, if iCurrPath is blank (fix some test case when activeTextEditor is null)
+				return "";
 			else if( statSync(iCurrPath).isFile )
 			{
 				iCurrPath = dirname(iCurrPath);

--- a/src/common/fileoperations.ts
+++ b/src/common/fileoperations.ts
@@ -39,6 +39,29 @@ export class FileOperations
 	}
 
 	/**
+	 * Allow iPath to be like "/sth", but append it to iCurrPath, not treating it as absolute path.
+	 */
+	public static getAbsoluteFromAlwaysRelativePath(iPath:string, iCurrPath:string, baseMustBeDir = false): string
+	{
+		if( iPath === undefined || iPath === "" || iCurrPath === undefined || iCurrPath === "" )
+			return "";
+
+		try
+		{
+			if( !baseMustBeDir && statSync(iCurrPath).isFile )
+			{
+				iCurrPath = dirname(iCurrPath);
+			}
+
+			return join(iCurrPath, iPath);
+		}
+		catch(error)
+		{
+			return "";
+		}
+	}
+
+	/**
 	 * Only return a matched path if the file actually exists.
 	 */
 	public static getAbsolutePathFromFuzzyPath(iPath:string, iCurrPath:string, iSuffix, baseMustBeDir = false): string

--- a/src/common/fileoperations.ts
+++ b/src/common/fileoperations.ts
@@ -9,7 +9,7 @@ import { Configuration } from '../configuration/configuration';
 
 export class FileOperations
 {
-	public static getAbsoluteFromRelativePath(iPath:string, iCurrPath:string): string
+	public static getAbsoluteFromRelativePath(iPath:string, iCurrPath:string, baseMustBeDir = false): string
 	{
 		if( iPath === undefined || iPath === "" || iCurrPath === undefined )
 			return "";
@@ -25,7 +25,7 @@ export class FileOperations
 				return join(iPath);
 			else if( iCurrPath === "" ) // fault tolerant: only fail when not absolute or relative-to-home path, if iCurrPath is blank (fix some test case when activeTextEditor is null)
 				return "";
-			else if( statSync(iCurrPath).isFile )
+			else if( !baseMustBeDir && statSync(iCurrPath).isFile )
 			{
 				iCurrPath = dirname(iCurrPath);
 			}
@@ -38,7 +38,10 @@ export class FileOperations
 		}
 	}
 
-	public static getAbsolutePathFromFuzzyPath(iPath:string, iCurrPath:string, iSuffix): string
+	/**
+	 * Only return a matched path if the file actually exists.
+	 */
+	public static getAbsolutePathFromFuzzyPath(iPath:string, iCurrPath:string, iSuffix, baseMustBeDir = false): string
 	{
 		if( iPath === undefined || iPath === "" || iCurrPath === undefined || iCurrPath === "" )
 			return "";
@@ -58,21 +61,23 @@ export class FileOperations
 		let p = path;
 		if( fileName.lastIndexOf(".") == -1 )
 		{
-			f += "." + iSuffix;
+			if (iSuffix !== '') {	// iSuffix may be empty now
+				f += "." + iSuffix;
+			}
 			p += f;
 		}
 		else
 		{
 			p += f;
 		}
-		retVal = this.getAbsoluteFromRelativePath(p, iCurrPath);
+		retVal = this.getAbsoluteFromRelativePath(p, iCurrPath, baseMustBeDir);
 		if(!existsSync(retVal))
 		{
 			if( fileName.indexOf("_") == -1 || fileName.indexOf("_") > 0 )
 			{
 				f = "_" + f;
 				p = path + f;
-				retVal = this.getAbsoluteFromRelativePath(p, iCurrPath);
+				retVal = this.getAbsoluteFromRelativePath(p, iCurrPath, baseMustBeDir);
 			}
 		}
 		if(existsSync(retVal))

--- a/src/configuration/confighandler.ts
+++ b/src/configuration/confighandler.ts
@@ -46,7 +46,7 @@ export class ConfigHandler
 			}
 			if( config.has("searchSubFoldersOfWorkspaceFolders") === true )
 			{
-				this.m_configuration.SearchSubFoldersOfWorkspaceFolders = config.get("searchSubFoldersOfWorkspaceFolders") as string;
+				this.m_configuration.SearchSubFoldersOfWorkspaceFolders = config.get("searchSubFoldersOfWorkspaceFolders") as string[];
 			}
 			if( config.has("searchPaths") === true )
 			{

--- a/src/configuration/confighandler.ts
+++ b/src/configuration/confighandler.ts
@@ -40,6 +40,18 @@ export class ConfigHandler
 			{
 				this.m_configuration.Extensions = config.get("extensions") as string[];
 			}
+			if( config.has("extraExtensionsForTypes") === true )
+			{
+				this.m_configuration.ExtraExtensionsForTypes = config.get("extraExtensionsForTypes") as object;
+			}
+			if( config.has("searchSubFoldersOfWorkspaceFolders") === true )
+			{
+				this.m_configuration.SearchSubFoldersOfWorkspaceFolders = config.get("searchSubFoldersOfWorkspaceFolders") as string;
+			}
+			if( config.has("searchPaths") === true )
+			{
+				this.m_configuration.SearchPaths = config.get("searchPaths") as string[];
+			}
 		}
 	}
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -6,11 +6,17 @@ export class Configuration
 {
 	private m_bound: RegExp;
 	private m_extensions: Array<string>;
+	private m_extraExtensionsForTypes: object;
+	private m_searchSubFoldersOfWorkspaceFolders: string;
+	private m_searchPaths: Array<string>;
 
 	public constructor()
 	{
 		this.m_bound = new RegExp("[\\s\\\"\\\'\\>\\<#]");
 		this.m_extensions = new Array<string>();
+		this.m_extraExtensionsForTypes = {};
+		this.m_searchSubFoldersOfWorkspaceFolders = '';
+		this.m_searchPaths = new Array<string>();
 	}
 
 	get Bound(): RegExp
@@ -45,5 +51,44 @@ export class Configuration
 	get Extensions(): Array<string>
 	{
 		return this.m_extensions;
+	}
+
+	set ExtraExtensionsForTypes(map: object)
+	{
+		if( map !== undefined )
+		{
+			this.m_extraExtensionsForTypes = map;
+		}
+	}
+
+	get ExtraExtensionsForTypes(): object
+	{
+		return this.m_extraExtensionsForTypes;
+	}
+
+	set SearchSubFoldersOfWorkspaceFolders(iPattern: string)
+	{
+		if( iPattern !== undefined )
+		{
+			this.m_searchSubFoldersOfWorkspaceFolders = iPattern;
+		}
+	}
+
+	get SearchSubFoldersOfWorkspaceFolders(): string
+	{
+		return this.m_searchSubFoldersOfWorkspaceFolders;
+	}
+
+	set SearchPaths(iPaths: Array<string>)
+	{
+		if( iPaths !== undefined )
+		{
+			this.m_searchPaths = iPaths;
+		}
+	}
+
+	get SearchPaths(): Array<string>
+	{
+		return this.m_searchPaths;
 	}
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -7,7 +7,7 @@ export class Configuration
 	private m_bound: RegExp;
 	private m_extensions: Array<string>;
 	private m_extraExtensionsForTypes: object;
-	private m_searchSubFoldersOfWorkspaceFolders: string;
+	private m_searchSubFoldersOfWorkspaceFolders: Array<string>;
 	private m_searchPaths: Array<string>;
 
 	public constructor()
@@ -15,7 +15,7 @@ export class Configuration
 		this.m_bound = new RegExp("[\\s\\\"\\\'\\>\\<#]");
 		this.m_extensions = new Array<string>();
 		this.m_extraExtensionsForTypes = {};
-		this.m_searchSubFoldersOfWorkspaceFolders = '';
+		this.m_searchSubFoldersOfWorkspaceFolders = new Array<string>();
 		this.m_searchPaths = new Array<string>();
 	}
 
@@ -66,15 +66,15 @@ export class Configuration
 		return this.m_extraExtensionsForTypes;
 	}
 
-	set SearchSubFoldersOfWorkspaceFolders(iPattern: string)
+	set SearchSubFoldersOfWorkspaceFolders(iPatterns: Array<string>)
 	{
-		if( iPattern !== undefined )
+		if( iPatterns !== undefined )
 		{
-			this.m_searchSubFoldersOfWorkspaceFolders = iPattern;
+			this.m_searchSubFoldersOfWorkspaceFolders = iPatterns;
 		}
 	}
 
-	get SearchSubFoldersOfWorkspaceFolders(): string
+	get SearchSubFoldersOfWorkspaceFolders(): Array<string>
 	{
 		return this.m_searchSubFoldersOfWorkspaceFolders;
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
-        "noLib": true,
+        "lib": [
+            "es6"
+        ],
         "sourceMap": true,
         "rootDir": "."
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "outDir": "out",
         "noLib": true,
         "sourceMap": true,

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
### Added
1. allow lookup the text string relative to all folder levels, from current document's folder, up to the embedding workspace folder (when current document is in a workspace folder).
    (First file found is opened immediately.  Thus, relative path to document's path is still highest priority)
2. also search relative to sub-folders under workspace folders (mainly under the "current" workspace folder, e.g. sub-folders like lib, src, class, public, vendor, etc). 
3. also search pre-defined search paths.

Remark:  the above logic is very practical, since I have experienced it in real use satisfactorily.

### Changed
- Now, if a file string does NOT contain a file extension, the current document's file extension is implicitly searched too and is assumed the default.  (e.g. import js without ".js" from .js file;  and a .rb ruby file require another ruby file without ".rb" too)
- Deprecate the "seito-openfile.extensions" setting, replaced by "seito-openfile.extraExtensionsForTypes" setting, to avoid searching too much file extensions for all document types.
- Optimize getAbsoluteFromRelativePath(), getAbsolutePathFromFuzzyPath() to avoid statSync() if sure current path must not be a file.

### Fixed
- Minor project compile and test issues.

Thanks for your concern.