### PR TITLE
Some more new features, like column positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                     "default": "[\\s\\\"\\'\\>\\<#;]",
                     "description": "The RegExp to define the bound of the path string"
                 },
+                "seito-openfile.lookupTildePathAlsoFromWorkspace": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to lookup path string which start with '~' relative to workspace if not found at user's home."
+                },
                 "seito-openfile.extensions": {
                     "type": "array",
                     "default": [],

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -177,7 +177,7 @@ export class OpenFileFromText {
 	public openDocument(iWord: string, iForceNewTab: boolean = false): Promise<any> {
 		return new Promise<any>((resolve, reject) => {
 			if (iWord === undefined || iWord === "")
-				reject("Something went wrong");
+				reject("Path is empty");
 
 			let fileAndLine = TextOperations.getPathAndPosition(iWord);
 			let p = this.resolvePath(fileAndLine.file);

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -251,6 +251,7 @@ export class OpenFileFromText {
 			if (lines.length > 1 && lines[lines.length - 1] === '') {	// pop last extra empty line after the last newline char
 				lines.pop();
 			}
+			lines = lines.map(line => line.replace(/((:\d+){1,2}):.*|:$/, '$1'));	// remove ":..." from ":line[:column]:..."
 			return lines;
 		}
 	}

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -262,7 +262,7 @@ export class OpenFileFromText {
 			if (lines.length > 1 && lines[lines.length - 1] === '') {	// pop last extra empty line after the last newline char
 				lines.pop();
 			}
-			lines = lines.map(line => line.replace(/((:\d+){1,2}):.*|:$/, '$1'));	// remove ":..." from ":line[:column]:..."
+			lines = lines.map(line => line.replace(/((:\d+){1,2}):.*/, '$1'));	// remove ":..." from ":line[:column]:..."
 			return lines;
 		}
 	}

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -92,15 +92,16 @@ export class TextOperations
 		if( end < i )
 			return "";
 
+		i--;	// Fix: allow cursor touching the right-edge of the target path to work properly
 		for(; i>=0; i--)
 		{
 			let t = iText[i];
 			if( t.match(bounds) !== null )
 			{
-				i++;
 				break;
 			}
 		}
+		i++;
 		for(; j<end; j++)
 		{
 			let t = iText[j];

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -109,11 +109,16 @@ export class TextOperations
 				break;
 			if (t === ':') {
 				let lineColMatches = iText.substring(i,j).match(/:\d+(:\d+)?$/);
-				if (lineColMatches) {	// if the string before this ':' is already ":<number>", gonna stops
-					if (lineColMatches[1] === undefined) {	// doesn't have column number before yet, so read any "<column>:" beyond this colon
-						let matches = iText.substring(j + 1, end).match(/^(\d+)($|:)/);
-						if (matches)
-							j += 1 + matches[1].length;
+				if (lineColMatches) {	// if the string before this ':' is already ":<number>[:<column>]", gonna stops, to remove any grep output like ":<matching-line>" at j
+					if (lineColMatches[1] === undefined) {	// doesn't have column number before yet, so read any valid ":<column>" pattern at this colon
+						let iSkipNum = j + 1;
+						while (iSkipNum < end && iText[iSkipNum] >= '0' && iText[iSkipNum] <= '9')
+							iSkipNum++;
+						if (iSkipNum > j + 1) {		// i.e. is ":<number>" at j
+							if (iSkipNum == end || iText[iSkipNum] == ':' || iText[iSkipNum].match(bounds) !== null) {	// at j, accept the column number if it's either :col or :col:... or :col<path-delimiter>
+								j = iSkipNum;
+							}
+						}
 					}
 					break;
 				}

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -46,21 +46,35 @@ export class TextOperations
 		return "";
 	}
 
-	public static getPathAndLineNumber(iWord:string): any
+	public static getPathAndPosition(iWord:string): any
 	{
 		let fileAndLine = {
 			file: iWord,
-			line: -1
+			line: -1,
+			column: -1
 		};
 		
-		if (fileAndLine.file.lastIndexOf(":") > -1) {
 			const lPos = iWord.lastIndexOf(":");
-			fileAndLine.file = iWord.substring(0, lPos);
-			fileAndLine.line = parseInt(iWord.substring(lPos+1));
-			if( isNaN(fileAndLine.line) )
-			{
-				fileAndLine.file = (iWord.length === lPos+1 ? iWord.substring(0,lPos) : iWord);
-				fileAndLine.line = -1;
+		if (lPos > -1) {
+			let numberAfterLastColon = parseInt(iWord.substring(lPos+1));	// use original parseInt, may not accurate and thus only limit start with number after colon
+			if( isNaN(numberAfterLastColon) ) {
+				fileAndLine.file = (iWord.length === lPos+1 ? iWord.substring(0,lPos) : iWord);	// FIXME: actually (iWord.length === lPos+1) never happen, because numberAfterLastColon == "" and isNaN("") === false
+				fileAndLine.line = fileAndLine.column = -1;
+			} else {
+				let b4Num = lPos - 1;
+				while (b4Num > 0 && iWord[b4Num] >= '0' && iWord[b4Num] <= '9')
+					--b4Num;
+				let fileEnd;
+				if (b4Num < lPos - 1 && iWord[b4Num] == ':') {	// i.e. :<integer> before this colon
+					fileAndLine.line = parseInt(iWord.substring(b4Num + 1, lPos));
+					fileAndLine.column = numberAfterLastColon;
+					fileEnd = b4Num;
+				} else {
+					fileAndLine.line = numberAfterLastColon;
+					fileAndLine.column = -1;
+					fileEnd = lPos;
+				}
+				fileAndLine.file = iWord.substring(0, fileEnd);
 			}
 		}
 		return fileAndLine;

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -53,8 +53,8 @@ export class TextOperations
 			line: -1,
 			column: -1
 		};
-		
-			const lPos = iWord.lastIndexOf(":");
+
+		const lPos = iWord.lastIndexOf(":");
 		if (lPos > -1) {
 			let numberAfterLastColon = parseInt(iWord.substring(lPos+1));	// use original parseInt, may not accurate and thus only limit start with number after colon
 			if( isNaN(numberAfterLastColon) ) {
@@ -107,11 +107,22 @@ export class TextOperations
 			let t = iText[j];
 			if( t.match(bounds) !== null )
 				break;
+			if (t === ':') {
+				let lineColMatches = iText.substring(i,j).match(/:\d+(:\d+)?$/);
+				if (lineColMatches) {	// if the string before this ':' is already ":<number>", gonna stops
+					if (lineColMatches[1] === undefined) {	// doesn't have column number before yet, so read any "<column>:" beyond this colon
+						let matches = iText.substring(j + 1, end).match(/^(\d+)($|:)/);
+						if (matches)
+							j += 1 + matches[1].length;
+					}
+					break;
+				}
+			}
 		}
 		return iText.substring(i,j);
 
 	}
-	
+
 	public static getWordOfSelection(iText: string, iSelection:vscode.Selection): string
 	{
 		let bounds: RegExp = ConfigHandler.Instance.Configuration.Bound;

--- a/src/configuration/confighandler.ts
+++ b/src/configuration/confighandler.ts
@@ -52,6 +52,10 @@ export class ConfigHandler
 			{
 				this.m_configuration.SearchPaths = config.get("searchPaths") as string[];
 			}
+			if( config.has("lookupTildePathAlsoFromWorkspace") === true )
+			{
+				this.m_configuration.LookupTildePathAlsoFromWorkspace = config.get("lookupTildePathAlsoFromWorkspace") as boolean;
+			}
 		}
 	}
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -9,6 +9,7 @@ export class Configuration
 	private m_extraExtensionsForTypes: object;
 	private m_searchSubFoldersOfWorkspaceFolders: Array<string>;
 	private m_searchPaths: Array<string>;
+	private m_lookupTildePathAlsoFromWorkspace: boolean;
 
 	public constructor()
 	{
@@ -17,6 +18,7 @@ export class Configuration
 		this.m_extraExtensionsForTypes = {};
 		this.m_searchSubFoldersOfWorkspaceFolders = new Array<string>();
 		this.m_searchPaths = new Array<string>();
+		this.m_lookupTildePathAlsoFromWorkspace = true;
 	}
 
 	get Bound(): RegExp
@@ -90,5 +92,16 @@ export class Configuration
 	get SearchPaths(): Array<string>
 	{
 		return this.m_searchPaths;
+	}
+
+	set LookupTildePathAlsoFromWorkspace(yesNo: boolean)
+	{
+		if ( yesNo !== undefined)
+			this.m_lookupTildePathAlsoFromWorkspace = yesNo;
+	}
+
+	get LookupTildePathAlsoFromWorkspace(): boolean
+	{
+		return this.m_lookupTildePathAlsoFromWorkspace;
 	}
 }

--- a/test/common/textoperations.test.ts
+++ b/test/common/textoperations.test.ts
@@ -100,19 +100,19 @@ suite("Text operation Tests", () => {
 	});
 
 	test("Get path and line number, \"windows absolute path string\"", () => {
-		let res = TextOperations.getPathAndLineNumber("l:\\Datas\\Test.txt");
+		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt");
 		assert.equal(res.file, "l:\\Datas\\Test.txt");
 		assert.equal(res.line, "-1");
 	});
 
 	test("Get path and line number, \"windows absolute path string and tailing colon\"", () => {
-		let res = TextOperations.getPathAndLineNumber("l:\\Datas\\Test.txt:");
+		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt:");
 		assert.equal(res.file, "l:\\Datas\\Test.txt");
 		assert.equal(res.line, "-1");
 	});
 
 	test("Get path and line number, \"windows absolute path string and tailing colon and number\"", () => {
-		let res = TextOperations.getPathAndLineNumber("l:\\Datas\\Test.txt:42");
+		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt:42");
 		assert.equal(res.file, "l:\\Datas\\Test.txt");
 		assert.equal(res.line, "42");
 	});


### PR DESCRIPTION
Thank you for considering the previous PR.  Here is some nice new feature to make the plug-in even more perfect.  Thank you.

### Added
- Add column positioning support, e.g. file:line:column
- Support single selection across multiple lines to open multiple files.
- Support open single/multiple files from the common output such as "grep -Hn".  i.e. for a selected line or cursor line which is like "file:line[:column]:content", the plug-in will extract "file:line[:column]" part to open.
- Add feature "lookupTildePathAlsoFromWorkspace" to search paths which start with '~' also relative to workspace, besides user's home. (disabled by default).  E.g. sample use case is like https://github.com/Microsoft/vscode/issues/14907

### Fixed
- allow cursor touching the right-edge of the target path to work properly. E.g. "filepath#" not work before when cursor is between "h" and "#".


## Remarks
- BTW, positioning of multiple files will not always work yet (seems only last opened document guaranteed to work).  I consider this as a bug in VS Code itself since we are using the "selection" option in showTextDocument().