### PR TITLE
Two useful features and a key binding

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test", "d:/Temp" ],
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": ["${workspaceRoot}/out/test/*.js"],

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This extension enables the user to open a file under the current cursor position. Just right-click on a pathname within a open document and select the ```open file under cursor``` option.
 If the file is found by vscode then it will open a new tab with this file.
 If the string is has an tailing number separated by a colon (i.e. `:23`) it will open the file at the specified line number.
-It is also possible to select one or more text segments in the document and open them. 
+It is also possible to select one or more text segments in the document and open them.
 
 ## Example
 
@@ -22,4 +22,16 @@ In that file the path strings could look like as follows:
 
 With this extension you can right-click on such a path and choose ```open file under cursor``` and VSCode will open a new tab with that file.
 
-Relative paths are always related to the currently open document.
+Relative paths are relative to the these folders (in order):
+
+1. Currently opened document's folder, and
+
+    (if it is within a workspace folder) the document's parent folders (up to the workspace folder).
+
+2. All workspace folders, and their sub-folders listed in the option `seito-openfile.searchSubFoldersOfWorkspaceFolders`.
+
+3. All search paths in the option `seito-openfile.searchPaths`.
+
+Remarks:
+- Absolute paths `/...` (`/` or `\`), if not found, are search like relative paths too.
+- If `~/...` paths not found from user's home, the step 2 of "Relative paths" is searched if option `seito-openfile.lookupTildePathAlsoFromWorkspace` is true.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open file
 
-This extension enables the user to open a file under the current cursor position. Just right-click on a pathname within a open document and select the ```open file under cursor``` option.
+This extension enables the user to open a file under the current cursor position. Just right-click on a pathname within a open document and select the ```open file under cursor``` option (or just press `Alt + P` without right-click).
 If the file is found by vscode then it will open a new tab with this file.
 
 If the string is has an tailing number separated by a colon (i.e. `:23`) it will open the file at the specified line number.  `:23:45` means line 23 column 45.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ With this extension you can right-click on such a path and choose ```open file u
 - allow `/path/to/sth` to be lookup as both absolute and relative path.  Useful for code like `projectFolder + '/path/to/sth'`.
 - support opening single or multiple files from *Linux `grep` output* with line number, which has the line pattern `file:line[:column]:content` (content is discarded).
 - fallback to VS Code's "Quick Open" input box if file not found.  (For handy custom search, or find containing files if the path is a folder in the workspace.)
+- include a simple "Open file like this file" command to call Quick Open with current file's relative path (without file extension), for lookup files like it.
 
 ## Path Lookup Detail
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This extension enables the user to open a file under the current cursor position. Just right-click on a pathname within a open document and select the ```open file under cursor``` option.
 If the file is found by vscode then it will open a new tab with this file.
-If the string is has an tailing number separated by a colon (i.e. `:23`) it will open the file at the specified line number.
+
+If the string is has an tailing number separated by a colon (i.e. `:23`) it will open the file at the specified line number.  `:23:45` means line 23 column 45.
+
 It is also possible to select one or more text segments in the document and open them.
 
 ## Example
@@ -22,7 +24,20 @@ In that file the path strings could look like as follows:
 
 With this extension you can right-click on such a path and choose ```open file under cursor``` and VSCode will open a new tab with that file.
 
-Relative paths are relative to the these folders (in order):
+## Main Features
+
+- support file string selection(s), or, no selection and auto *detect path outside quotes* or within quotes `'file-path'`.
+- support *opening multiple files* at a time.  (Either a multi-lined selection or multiple selections.)
+- path lookup from multiple locations to find *nearest match*: absolute, current document's folder, workspace, workspace's `src`, defined search paths, etc.
+- *line and column positioning* with `file:line:column`.
+- possible to open like `[src/]class/SomeClass.php` from just `someClass`.  (Use case insensitive file system to support the different in letter case.)
+- allow `/path/to/sth` to be lookup as both absolute and relative path.  Useful for code like `projectFolder + '/path/to/sth'`.
+- support opening single or multiple files from *Linux `grep` output* with line number, which has the line pattern `file:line[:column]:content` (content is discarded).
+- fallback to VS Code's "Quick Open" input box if file not found.  (For handy custom search, or find containing files if the path is a folder in the workspace.)
+
+## Path Lookup Detail
+
+Relative paths are relative to the these folders (in listed order):
 
 1. Currently opened document's folder, and
 
@@ -33,5 +48,5 @@ Relative paths are relative to the these folders (in order):
 3. All search paths in the option `seito-openfile.searchPaths`.
 
 Remarks:
-- Absolute paths `/...` (`/` or `\`), if not found, are search like relative paths too.
+- Absolute paths `/...` (`/` or `\`), if not found, are searched like relative paths too.
 - If `~/...` paths not found from user's home, the step 2 of "Relative paths" is searched if option `seito-openfile.lookupTildePathAlsoFromWorkspace` is true.

--- a/package.json
+++ b/package.json
@@ -72,12 +72,14 @@
                 "seito-openfile.extraExtensionsForTypes": {
                     "type": "object",
                     "default": {
-                        "js": [
-                            "jsx"
-                        ],
-                        "jsx": [
-                            "js"
-                        ]
+                        "js": ["jsx"],
+                        "jsx": ["js"],
+                        "ts": ["js", "jsx"],
+                        "vue": ["js", "jsx"],
+                        "c": ["h"],
+                        "cpp": ["h", "hpp"],
+                        "m": ["h"],
+                        "mm": ["h", "hpp"]
                     },
                     "description": "Known suffixes to look for when file string has no suffix, according to current document's type. (suffix match is relative to current document's parent folders only)"
                 },

--- a/package.json
+++ b/package.json
@@ -28,14 +28,23 @@
                 "command": "seito-openfile.openFileFromText",
                 "category": "File",
                 "title": "Open file under cursor"
+            },
+            {
+                "command": "seito-openfile.openFileLikeThisFile",
+                "category": "File",
+                "title": "Open file like this file"
             }
         ],
         "keybindings": [
             {
-              "command": "seito-openfile.openFileFromText",
-              "key": "alt+p"
+                "command": "seito-openfile.openFileFromText",
+                "key": "alt+p"
+            },
+            {
+                "command": "seito-openfile.openFileLikeThisFile",
+                "key": "alt+q"
             }
-        ],
+          ],
         "menus": {
             "commandPalette": [
                 {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,12 @@
                 "title": "Open file under cursor"
             }
         ],
+        "keybindings": [
+            {
+              "command": "seito-openfile.openFileFromText",
+              "key": "alt+p"
+            }
+        ],
         "menus": {
             "commandPalette": [
                 {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "keybindings": [
             {
                 "command": "seito-openfile.openFileFromText",
-                "key": "alt+p"
+                "key": "alt+p",
+                "when": "editorTextFocus"
             },
             {
                 "command": "seito-openfile.openFileLikeThisFile",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
                     "type": "array",
                     "default": [],
                     "description": "Paths to be added to search at last, for relative paths"
+                },
+                "seito-openfile.notFoundTriggerQuickOpen": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "When enabled, if (a sole) file is not found by the normal logic, trigger VS Code's Quick Open input box for further search."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
                     "default": [],
                     "description": "Paths to be added to search at last, for relative paths"
                 },
+                "seito-openfile.leadingPathMapping": {
+                    "type": "object",
+                    "default": { },
+                    "description": "Rewrite leading path segments to another path, like {\"source/path\": \"target/path\"}.  Both source and target paths must be full match of single or multiple folder levels.  E.g. if want '@/' to mean relative to workspace, you may write {\"@\": \"\"} to remove the '@' folder level.  Be care any mistake of this setting can cause unexpected file open failures."
+                },
                 "seito-openfile.notFoundTriggerQuickOpen": {
                     "type": "boolean",
                     "default": true,

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -67,11 +67,14 @@ export class OpenFileFromText {
 	 * @param inputPath text to deduce path from
 	 * @return empty string if not found
 	 */
-	public resolvePath(inputPath: string): string {
+	public resolvePath(inputPath: string, iCurrentDocFileName?: string): string {
 		let debug = (...args) => {
 			// console.log(...args);		// un-comment this to debug
 		};
-		let currentDocFileName = this.editor ? this.editor.document.fileName : '';
+		let currentDocUri : vscode.Uri = this.editor ? this.editor.document.uri : null;
+		if (iCurrentDocFileName !== undefined)
+			currentDocUri = vscode.Uri.file(iCurrentDocFileName);
+		let currentDocFileName = currentDocUri ? currentDocUri.fsPath : '';
 		let basePath = dirname(currentDocFileName);
 
 		// Normalize \ to / in the file string (\ not work for existsSync on linux-like), to support e.g. "use namespace\Class;" with path path/to/class/namespace/Class.php in PHP.
@@ -85,7 +88,7 @@ export class OpenFileFromText {
 		let leadingPathMapping = ConfigHandler.Instance.Configuration.LeadingPathMapping;
 		let leadingPaths = Object.keys(leadingPathMapping);
 		let i = leadingPaths.length;
-		for (; --i > 0; ) {	    // need to loop backward
+		for (; i-- > 0; ) {	    // need to loop backward
 			let leadingPath = leadingPaths[i];
 			if (tempInputPathWithoutLeadingSlash.startsWith(leadingPath /*this.trimPathSeparator(leadingPath)*/) &&
 					(tempInputPathWithoutLeadingSlash.length == leadingPath.length || tempInputPathWithoutLeadingSlash[leadingPath.length] == '/') ) {
@@ -93,7 +96,9 @@ export class OpenFileFromText {
 				let remainPath = tempInputPathWithoutLeadingSlash.substr(leadingPath.length);	// cut leadingPath
 				if (mappedPath == '')	// delete folder levels
 					remainPath = this.trimPathSeparator(remainPath);
-				inputPath = (isSlashAbsolutePath ? '/' : '') + mappedPath + remainPath;		// remainPath must either be empty or start with '/', as checked above
+				let newPath = (isSlashAbsolutePath ? '/' : '') + mappedPath + remainPath;		// remainPath must either be empty or start with '/', as checked above
+				debug(inputPath + " --> translated to --> " + newPath);
+				inputPath = newPath;
 				break;
 			}
 		}
@@ -134,8 +139,8 @@ export class OpenFileFromText {
 		let isWithinAWorkspaceFolder = false;
 		let currentWorkspaceFolderObj = null;
 		let currentWorkspaceFolder = null;
-		if (this.m_currFile && this.m_currFile.scheme === 'file') {
-			currentWorkspaceFolderObj = vscode.workspace.getWorkspaceFolder(this.m_currFile);
+		if (currentDocUri && currentDocUri.scheme === 'file') {
+			currentWorkspaceFolderObj = vscode.workspace.getWorkspaceFolder(currentDocUri);
 			if (currentWorkspaceFolderObj) {
 				isWithinAWorkspaceFolder = true;
 				currentWorkspaceFolder = currentWorkspaceFolderObj.uri.fsPath;
@@ -192,7 +197,7 @@ export class OpenFileFromText {
 
 			// Search some subfolders under the workspace folder
 			// let workspaceSubFolders = ["lib", "src", "app", "class", "module", "inc", "vendor", "public"]; // "class*", "module*", "inc*"
-			let subFoldersPattern = this.configHandler.Configuration.SearchSubFoldersOfWorkspaceFolders; // default: "@(lib*|src|app|class*|module*|inc*|vendor?(s)|public)";
+			let subFoldersPattern = this.configHandler.Configuration.SearchSubFoldersOfWorkspaceFolders;
 			let workspaceSubFolders = glob.sync(subFoldersPattern, { cwd: workspaceFolder });
 
 			debug('Searching sub-folders of workspaceFolder', workspaceFolder, 'are', workspaceSubFolders.join(','));

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -285,16 +285,17 @@ export class OpenFileFromText {
 		return '';
 	}
 
-	public getWordRanges(selection: vscode.Selection) {
+	public getWordRanges(selection: vscode.Selection, iDocument?: vscode.TextDocument) {
 		let line: string;
 		let start: vscode.Position;
+		let document = iDocument !== undefined ? iDocument : this.editor.document;
 		if (selection.isEmpty) {
-			line = this.editor.document.lineAt(selection.active.line).text;
+			line = document.lineAt(selection.active.line).text;
 			start = selection.active;
 			return [TextOperations.getWordBetweenBounds(line, start, this.configHandler.Configuration.Bound)];
 		}
 		else {
-			let multiLinesText = this.editor.document.getText(selection);
+			let multiLinesText = document.getText(selection);
 			let lines = multiLinesText.split(/\r\n?|\n/);
 			if (lines.length > 1 && lines[lines.length - 1] === '') {	// pop last extra empty line after the last newline char
 				lines.pop();

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -27,6 +27,10 @@ export class OpenFileFromText {
 		this.editor = vscode.window.activeTextEditor;
 	}
 
+	public trimPathSeparator(path : string) {
+		return path.replace(/^[\/\\\\]+|[\/\\\\]+$/g, '');
+	}
+
 	public execute() {
 		let numSelections = this.editor.selections.length;
 		let isOpeningMultipleFiles = numSelections > 1;	// if there are more than 1 file to open, open in new tab for all.
@@ -44,7 +48,7 @@ export class OpenFileFromText {
 						// Note it is safe below to cut prefix '/' to make the absolute path relative, because if it is an absolute path and file exists, it should have opened directly.
 						vscode.commands.executeCommand(
 							'workbench.action.quickOpen',
-							word.replace(/^[\/\\\\]+|[\/\\\\]+$/g, '') 	// trim / and \ from both ends of file string
+							this.trimPathSeparator(word) 	// trim / and \ from both ends of file string
 						);
 					}
 				});
@@ -73,18 +77,38 @@ export class OpenFileFromText {
 		// Normalize \ to / in the file string (\ not work for existsSync on linux-like), to support e.g. "use namespace\Class;" with path path/to/class/namespace/Class.php in PHP.
 		inputPath = inputPath.replace(/\\/g, '/');
 
+		let isAbsolutePath = isAbsolute(inputPath);
+		let isSlashAbsolutePath = isAbsolutePath && inputPath.match(/^[\/\\][^\/\\]/);
+
+		// translate path inputPath with "leadingPathMapping"
+		let tempInputPathWithoutLeadingSlash = isSlashAbsolutePath ? inputPath.substr(1) : inputPath;	// for temporary match with leadingPaths only
+		let leadingPathMapping = ConfigHandler.Instance.Configuration.LeadingPathMapping;
+		let leadingPaths = Object.keys(leadingPathMapping);
+		let i = leadingPaths.length;
+		for (; --i > 0; ) {	    // need to loop backward
+			let leadingPath = leadingPaths[i];
+			if (tempInputPathWithoutLeadingSlash.startsWith(leadingPath /*this.trimPathSeparator(leadingPath)*/) &&
+					(tempInputPathWithoutLeadingSlash.length == leadingPath.length || tempInputPathWithoutLeadingSlash[leadingPath.length] == '/') ) {
+				let mappedPath = this.trimPathSeparator(leadingPathMapping[leadingPath]);
+				let remainPath = tempInputPathWithoutLeadingSlash.substr(leadingPath.length);	// cut leadingPath
+				if (mappedPath == '')	// delete folder levels
+					remainPath = this.trimPathSeparator(remainPath);
+				inputPath = (isSlashAbsolutePath ? '/' : '') + mappedPath + remainPath;		// remainPath must either be empty or start with '/', as checked above
+				break;
+			}
+		}
+
 		// First, try relative to current document's folder, or absolute path, or relative to "~"
 		let p = FileOperations.getAbsoluteFromRelativePath(inputPath, basePath, true);
 		if (existsSync(p) && lstatSync(p).isFile())
 			return p;
 
 		let isHomePath = inputPath[0] === "~";
-		let isAbsolutePath = isAbsolute(inputPath);
 		let tryWorkspaceHomePath = false;
 		if (isHomePath && ConfigHandler.Instance.Configuration.LookupTildePathAlsoFromWorkspace)
 			tryWorkspaceHomePath = true;
 		if ( (isHomePath && !tryWorkspaceHomePath) ||
-				(isAbsolutePath && !inputPath.match(/^[\/\\][^\/\\]/)) ) { // only relative path (or absolute path start with single slash/backslash, not C: drive) can continue to lookup from other folders
+				(isAbsolutePath && !isSlashAbsolutePath) ) { // only relative path (or absolute path start with single slash/backslash, not C: drive) can continue to lookup from other folders
 			return '';
 		}
 

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -288,7 +288,7 @@ export class OpenFileFromText {
 	public getWordRanges(selection: vscode.Selection) {
 		let line: string;
 		let start: vscode.Position;
-		if (this.editor.selection.isEmpty) {
+		if (selection.isEmpty) {
 			line = this.editor.document.lineAt(selection.active.line).text;
 			start = selection.active;
 			return [TextOperations.getWordBetweenBounds(line, start, this.configHandler.Configuration.Bound)];

--- a/src/commands/openFileLikeThisFile.ts
+++ b/src/commands/openFileLikeThisFile.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { parse, join } from 'path';
+
+
+/**
+ * May just keep the logic simple (relative path, cut extension). For advanced similar feature, there is already
+ * an VSCode extension like "Quick Open Related Files".
+ */
+export class OpenFileLikeThisFile {
+    public static execute() {
+        let editor = vscode.window.activeTextEditor;
+        if (!(editor &&
+                editor.document &&
+                editor.document.uri)) {
+            return;
+        }
+        let uri = editor.document.uri;
+        let path = parse(vscode.workspace.asRelativePath(uri.fsPath, false));
+
+        vscode.commands.executeCommand(
+            'workbench.action.quickOpen',
+            join(path.dir, path.name)  // only cut file extension
+        );
+    }
+};

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -58,7 +58,7 @@ export class TextOperations
 		if (lPos > -1) {
 			let numberAfterLastColon = parseInt(iWord.substring(lPos+1));	// use original parseInt, may not accurate and thus only limit start with number after colon
 			if( isNaN(numberAfterLastColon) ) {
-				fileAndLine.file = (iWord.length === lPos+1 ? iWord.substring(0,lPos) : iWord);	// FIXME: actually (iWord.length === lPos+1) never happen, because numberAfterLastColon == "" and isNaN("") === false
+				fileAndLine.file = (iWord.length === lPos+1 ? iWord.substring(0,lPos) : iWord);
 				fileAndLine.line = fileAndLine.column = -1;
 			} else {
 				let b4Num = lPos - 1;

--- a/src/configuration/confighandler.ts
+++ b/src/configuration/confighandler.ts
@@ -9,11 +9,20 @@ export class ConfigHandler
 	private static m_instance: ConfigHandler;
 	private m_configuration: Configuration;
 
-	public constructor()
+	public constructor(shouldFollowVsCodeSettings : boolean = true)
 	{
 		this.m_configuration = new Configuration();
-		this.onConfigChanged();
-		vscode.workspace.onDidChangeConfiguration(this.onConfigChanged, this);
+		if (shouldFollowVsCodeSettings) {
+			this.onConfigChanged();
+			vscode.workspace.onDidChangeConfiguration(this.onConfigChanged, this);
+		}
+	}
+
+	// for unit test not to be affected by current user's settings
+	static preInitInstanceNotFollowingVsCodeSettings() {
+		// if (this.m_instance)
+		// 	return;
+		this.m_instance = new this(false);
 	}
 
 	static get Instance(): ConfigHandler

--- a/src/configuration/confighandler.ts
+++ b/src/configuration/confighandler.ts
@@ -56,6 +56,10 @@ export class ConfigHandler
 			{
 				this.m_configuration.LookupTildePathAlsoFromWorkspace = config.get("lookupTildePathAlsoFromWorkspace") as boolean;
 			}
+			if( config.has("notFoundTriggerQuickOpen") === true )
+			{
+				this.m_configuration.NotFoundTriggerQuickOpen = config.get("notFoundTriggerQuickOpen") as boolean;
+			}
 		}
 	}
 }

--- a/src/configuration/confighandler.ts
+++ b/src/configuration/confighandler.ts
@@ -56,6 +56,10 @@ export class ConfigHandler
 			{
 				this.m_configuration.LookupTildePathAlsoFromWorkspace = config.get("lookupTildePathAlsoFromWorkspace") as boolean;
 			}
+			if( config.has("leadingPathMapping") === true )
+			{
+				this.m_configuration.LeadingPathMapping = config.get("leadingPathMapping") as { [ leadingPath : string ] : string };
+			}
 			if( config.has("notFoundTriggerQuickOpen") === true )
 			{
 				this.m_configuration.NotFoundTriggerQuickOpen = config.get("notFoundTriggerQuickOpen") as boolean;

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -10,6 +10,7 @@ export class Configuration
 	private m_searchSubFoldersOfWorkspaceFolders: Array<string>;
 	private m_searchPaths: Array<string>;
 	private m_lookupTildePathAlsoFromWorkspace: boolean;
+	private m_notFoundTriggerQuickOpen: boolean;
 
 	public constructor()
 	{
@@ -19,6 +20,7 @@ export class Configuration
 		this.m_searchSubFoldersOfWorkspaceFolders = new Array<string>();
 		this.m_searchPaths = new Array<string>();
 		this.m_lookupTildePathAlsoFromWorkspace = true;
+		this.m_notFoundTriggerQuickOpen = true;
 	}
 
 	get Bound(): RegExp
@@ -103,5 +105,16 @@ export class Configuration
 	get LookupTildePathAlsoFromWorkspace(): boolean
 	{
 		return this.m_lookupTildePathAlsoFromWorkspace;
+	}
+
+	set NotFoundTriggerQuickOpen(yesNo: boolean)
+	{
+		if ( yesNo !== undefined)
+			this.m_notFoundTriggerQuickOpen = yesNo;
+	}
+
+	get NotFoundTriggerQuickOpen(): boolean
+	{
+		return this.m_notFoundTriggerQuickOpen;
 	}
 }

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -10,6 +10,7 @@ export class Configuration
 	private m_searchSubFoldersOfWorkspaceFolders: Array<string>;
 	private m_searchPaths: Array<string>;
 	private m_lookupTildePathAlsoFromWorkspace: boolean;
+	private m_leadingPathMapping: { [ leadingPath : string ] : string };
 	private m_notFoundTriggerQuickOpen: boolean;
 
 	public constructor()
@@ -20,6 +21,7 @@ export class Configuration
 		this.m_searchSubFoldersOfWorkspaceFolders = new Array<string>();
 		this.m_searchPaths = new Array<string>();
 		this.m_lookupTildePathAlsoFromWorkspace = true;
+		this.m_leadingPathMapping = {};
 		this.m_notFoundTriggerQuickOpen = true;
 	}
 
@@ -105,6 +107,17 @@ export class Configuration
 	get LookupTildePathAlsoFromWorkspace(): boolean
 	{
 		return this.m_lookupTildePathAlsoFromWorkspace;
+	}
+
+	set LeadingPathMapping(mappings: { [ leadingPath : string ] : string })
+	{
+		if ( mappings !== undefined)
+			this.m_leadingPathMapping = mappings;
+	}
+
+	get LeadingPathMapping(): { [ leadingPath : string ] : string }
+	{
+		return this.m_leadingPathMapping;
 	}
 
 	set NotFoundTriggerQuickOpen(yesNo: boolean)

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -15,7 +15,7 @@ export class Configuration
 
 	public constructor()
 	{
-		this.m_bound = new RegExp("[\\s\\\"\\\'\\>\\<#]");
+		this.m_bound = new RegExp("[\\s\\\"\\\'\\>\\<#;]");
 		this.m_extensions = new Array<string>();
 		this.m_extraExtensionsForTypes = {};
 		this.m_searchSubFoldersOfWorkspaceFolders = new Array<string>();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
 import * as vscode from 'vscode';
 import {ConfigHandler} from './configuration/confighandler';
 import {OpenFileFromText} from './commands/openFileFromText';
+import {OpenFileLikeThisFile} from './commands/openFileLikeThisFile';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -22,6 +23,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('seito-openfile.openFileFromText', openFile.execute, openFile)
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand('seito-openfile.openFileLikeThisFile', OpenFileLikeThisFile.execute, OpenFileLikeThisFile)
     );
 }
 

--- a/test/common/fileoperations.test.ts
+++ b/test/common/fileoperations.test.ts
@@ -249,5 +249,21 @@ suite("File operation Tests", () => {
 		assert.equal(res, "d:\\Temp\\test\\testcase.txt");
 	});
 
+	test("A multi-lined selection should split, and support cutting :content from lines of grep/ack output like file:line:column:content", (done) => {
+		let line1 = 'd:/Temp/test/testcase.txt:4:3:the forth line\n';
+		let line2 = 'd:/Temp/test/dir1/testcase2.ts:1:line 1\n';
+		let content = line1 + line2;
+		vscode.workspace.openTextDocument({ content: content }).then((doc) => {
+			let anchor = new vscode.Position(0, 0);
+			let active = new vscode.Position(2, 0);
+			let files = openFile.getWordRanges(new vscode.Selection(anchor, active), doc);
+			assert.equal(2, files.length);
+			assert.equal('d:/Temp/test/testcase.txt:4:3', files[0]);
+			assert.equal('d:/Temp/test/dir1/testcase2.ts:1', files[1]);
+			done();
+		}, (reason: Error) => {
+			done("Cannot open untitled text: " + reason.message);
+		});
+	});
 });
 

--- a/test/common/textoperations.test.ts
+++ b/test/common/textoperations.test.ts
@@ -13,6 +13,7 @@ import {initialize, teardown} from '../initialize';
 import {writeFileSync, writeFile, unlink, unlinkSync, mkdirSync, rmdirSync} from 'fs';
 import {TextOperations} from '../../src/common/textoperations';
 import {ConfigHandler} from '../../src/configuration/confighandler';
+ConfigHandler.preInitInstanceNotFollowingVsCodeSettings();
 
 let dirname = "d:/temp/test";
 let filename = "d:/temp/test/testcase.txt";
@@ -55,9 +56,21 @@ suite("Text operation Tests", () => {
 		assert.equal(res, "welt");
 	});
 
+	test("Get word, empty quoted string", () => {
+		let pos = new vscode.Position(2, 4);
+		let res = TextOperations.getWordBetweenBounds('hi ""', pos)
+		assert.equal(res, "");
+	});
+
 	test("Get word, comment line", () => {
 		let pos = new vscode.Position(2, 6);
-		let res = TextOperations.getWordBetweenBounds('# hi/welt', pos)
+		let res = TextOperations.getWordBetweenBounds('#hi/welt', pos)
+		assert.equal(res, "hi/welt");
+	});
+
+	test("Get word, space delimited", () => {
+		let pos = new vscode.Position(2, 6);
+		let res = TextOperations.getWordBetweenBounds('hey hi/welt', pos)
 		assert.equal(res, "hi/welt");
 	});
 
@@ -92,29 +105,67 @@ suite("Text operation Tests", () => {
 	});
 
 	test("Get word, right most position, with config", () => {
-		let configHandler = ConfigHandler.Instance;
-		configHandler.Configuration.Bound = /\:/;
 		let pos = new vscode.Position(2, 7);
-		let res = TextOperations.getWordBetweenBounds('hi ":welt da:"', pos, configHandler.Configuration.Bound)
+		let res = TextOperations.getWordBetweenBounds('hi ":welt da:"', pos, /\:/)
 		assert.equal(res, "welt da");
+	});
+
+	test("Get word, with line number and a colon, cursor before first colon", () => {
+		let pos = new vscode.Position(2, 7);
+		let res = TextOperations.getWordBetweenBounds("l:/Datas/Test.txt:10:", pos);
+		assert.equal(res, "l:/Datas/Test.txt:10");
+	});
+
+	test("Get word, with line number and a colon, cursor at line number", () => {
+		let pos = new vscode.Position(2, 18);
+		let res = TextOperations.getWordBetweenBounds("l:/Datas/Test.txt:10:", pos);
+		assert.equal(res, "l:/Datas/Test.txt:10");
+	});
+
+	test("Get word, with line column and a colon, cursor before first colon", () => {
+		let pos = new vscode.Position(2, 7);
+		let res = TextOperations.getWordBetweenBounds("l:/Datas/Test.txt:42:10:content", pos);
+		assert.equal(res, "l:/Datas/Test.txt:42:10");
+	});
+
+	test("Get word, with line column and a colon, cursor at line number", () => {
+		let pos = new vscode.Position(2, 18);
+		let res = TextOperations.getWordBetweenBounds("l:/Datas/Test.txt:42:10:content", pos);
+		assert.equal(res, "l:/Datas/Test.txt:42:10");
+	});
+
+	test("Get word, with line column and a colon, cursor at column number", () => {
+		let pos = new vscode.Position(2, 21);
+		let res = TextOperations.getWordBetweenBounds("l:/Datas/Test.txt:42:10:content", pos);
+		assert.equal(res, "l:/Datas/Test.txt:42:10");
 	});
 
 	test("Get path and line number, \"windows absolute path string\"", () => {
 		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt");
 		assert.equal(res.file, "l:\\Datas\\Test.txt");
 		assert.equal(res.line, "-1");
+		assert.equal(res.column, "-1");
 	});
 
 	test("Get path and line number, \"windows absolute path string and tailing colon\"", () => {
 		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt:");
 		assert.equal(res.file, "l:\\Datas\\Test.txt");
 		assert.equal(res.line, "-1");
+		assert.equal(res.column, "-1");
 	});
 
 	test("Get path and line number, \"windows absolute path string and tailing colon and number\"", () => {
 		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt:42");
 		assert.equal(res.file, "l:\\Datas\\Test.txt");
 		assert.equal(res.line, "42");
+		assert.equal(res.column, "-1");
+	});
+
+	test("Get path and line column, \"windows absolute path string and line:column\"", () => {
+		let res = TextOperations.getPathAndPosition("l:\\Datas\\Test.txt:42:10");
+		assert.equal(res.file, "l:\\Datas\\Test.txt");
+		assert.equal(res.line, "42");
+		assert.equal(res.column, "10");
 	});
 
 

--- a/test/initialize.ts
+++ b/test/initialize.ts
@@ -9,7 +9,7 @@ let files = [
 	{"name": "d:/Temp/test/_test3.scss", "content": ""},
 	{"name": "d:/Temp/test/testcase.txt", "content": "the first line\r\nthe second line\r\n\r\nthe forth line\r\n\r\nthe sixth line"},
 	{"name": "d:\\common\\test.ts", "content": ""},
-	{"name": "d:/Temp/test/dir1/testcase2.ts", "content": ""},
+	{"name": "d:/Temp/test/dir1/testcase2.ts", "content": "line 1"},
 	{"name": "d:/Temp/src/Class1.ts", "content": ""},
 ];
 

--- a/test/initialize.ts
+++ b/test/initialize.ts
@@ -1,6 +1,6 @@
 import {writeFileSync, writeFile, unlink, unlinkSync, mkdirSync, rmdirSync, existsSync} from 'fs';
 
-let dirnames = ["d:\\Temp\\test", "d:/common"];
+let dirnames = ["d:\\Temp\\test", "d:\\Temp\\test\\dir1", "d:\\Temp\\src", "d:/common"];
 let files = [
 	{"name": "d:\\Temp\\test.ts", "content": ""},
 	{"name": "d:/Temp/test/hans.txt", "content": ""},
@@ -9,6 +9,8 @@ let files = [
 	{"name": "d:/Temp/test/_test3.scss", "content": ""},
 	{"name": "d:/Temp/test/testcase.txt", "content": "the first line\r\nthe second line\r\n\r\nthe forth line\r\n\r\nthe sixth line"},
 	{"name": "d:\\common\\test.ts", "content": ""},
+	{"name": "d:/Temp/test/dir1/testcase2.ts", "content": ""},
+	{"name": "d:/Temp/src/Class1.ts", "content": ""},
 ];
 
 export function initialize(): Promise<any>


### PR DESCRIPTION
### Added
- If file not found, default to trigger VS Code's "Quick Open" input box with pre-filled file path (for custom lookup or lookup of folder).
- New setting "seito-openfile.leadingPathMapping" to rewrite leading path segments.
- Add "Main Features" and "Path Lookup Detail" to README.md.
- Add key binding Alt + P.

The "seito-openfile.leadingPathMapping" setting could also solves #4 (need manual setting).