### PR TITLE
Add a rather common case to leadingPathMapping { "@*": "*" }

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
                 "seito-openfile.leadingPathMapping": {
                     "type": "object",
                     "default": { },
-                    "description": "Rewrite leading path segments to another path, like {\"source/path\": \"target/path\"}.  Both source and target paths must be full match of single or multiple folder levels.  E.g. if want '@/' to mean relative to workspace, you may write {\"@\": \"\"} to remove the '@' folder level.  Be care any mistake of this setting can cause unexpected file open failures."
+                    "description": "Rewrite leading path segments to another path, like {\"source/path\": \"target/path\"}.  Both source and target paths must be full match of single or multiple folder levels.  E.g. if want '@/' to mean relative to workspace, you may write {\"@\": \"\"} to remove the '@' folder level.  Also support ending wildcard '*', like {\"@*\": \"*\"}.  Be care any mistake of this setting can cause unexpected file open failures."
                 },
                 "seito-openfile.notFoundTriggerQuickOpen": {
                     "type": "boolean",

--- a/src/common/fileoperations.ts
+++ b/src/common/fileoperations.ts
@@ -25,7 +25,7 @@ export class FileOperations
 				return join(iPath);
 			else if( iCurrPath === "" ) // fault tolerant: only fail when not absolute or relative-to-home path, if iCurrPath is blank (fix some test case when activeTextEditor is null)
 				return "";
-			else if( !baseMustBeDir && statSync(iCurrPath).isFile )
+			else if( !baseMustBeDir && statSync(iCurrPath).isFile() )
 			{
 				iCurrPath = dirname(iCurrPath);
 			}
@@ -48,7 +48,7 @@ export class FileOperations
 
 		try
 		{
-			if( !baseMustBeDir && statSync(iCurrPath).isFile )
+			if( !baseMustBeDir && statSync(iCurrPath).isFile() )
 			{
 				iCurrPath = dirname(iCurrPath);
 			}

--- a/test/common/fileoperations.test.ts
+++ b/test/common/fileoperations.test.ts
@@ -248,6 +248,11 @@ suite("File operation Tests", () => {
 		res = openFile.resolvePath("b/test/testcase.txt", "d:/Temp/test.ts");
 		assert.equal(res, "d:\\Temp\\test\\testcase.txt");
 	});
+	test("resolvePath, resolve path with path substitution, using prefix match with ending '*', by leadingPathMapping.", () => {
+		ConfigHandler.Instance.Configuration.LeadingPathMapping = { '$*': '*' };
+		let res = openFile.resolvePath("$test/dir1/testcase2", "d:/Temp/test.ts");
+		assert.equal(res, "d:\\Temp\\test\\dir1\\testcase2.ts");
+	});
 
 	test("A multi-lined selection should split, and support cutting :content from lines of grep/ack output like file:line:column:content", (done) => {
 		let line1 = 'd:/Temp/test/testcase.txt:4:3:the forth line\n';


### PR DESCRIPTION
And fixed a minor bug of `isFile` not calling as `isFile()` in getAbsoluteFromRelativePath()