### PR TITLE
I think a few cases are quite common and worth to add as path delimters too.  Thanks!

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
                 "seito-openfile.leadingPathMapping": {
                     "type": "object",
                     "default": { },
-                    "description": "Rewrite leading path segments to another path, like {\"source/path\": \"target/path\"}.  Both source and target paths must be full match of single or multiple folder levels.  E.g. if want '@/' to mean relative to workspace, you may write {\"@\": \"\"} to remove the '@' folder level.  Also support ending wildcard '*', like {\"@*\": \"*\"}.  Be care any mistake of this setting can cause unexpected file open failures."
+                    "description": "Rewrite leading path segments to another path, like {\"source/path\": \"target/path\"}.  Both source and target paths must be full match of single or multiple folder levels.  E.g. if want '@/' to mean relative to workspace, you may write {\"@\": \"\"} to remove the '@' folder level.  Also support ending wildcard '*', like {\"@*\": \"*\"}.  Later value has higher precedence.  Be care any mistake of this setting can cause unexpected file open failures."
                 },
                 "seito-openfile.notFoundTriggerQuickOpen": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
             "properties": {
                 "seito-openfile.wordbound": {
                     "type": "string",
-                    "default": "[\\s\\\"\\'\\>\\<#;]",
+                    "default": "[\\s\\\"\\'\\>\\<#;?{}]",
                     "description": "The RegExp to define the bound of the path string"
                 },
                 "seito-openfile.lookupTildePathAlsoFromWorkspace": {

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -69,7 +69,7 @@ export class OpenFileFromText {
 		let leadingPaths = Object.keys(leadingPathMapping);
 		let i = leadingPaths.length;
 		for (; i-- > 0; ) {	    // need to loop backward
-			let leadingPath = leadingPaths[i];
+			let leadingPath = leadingPaths[i].replace(/\*\?$/, '*');	// allow leadingPathMapping = { "$*": "*", "$*?": "" } to work.  Since a key "$*" cannot appear twice.
 			let isEndWithStar = leadingPath.endsWith('*');
 			let isPrefix = tempInputPathWithoutLeadingSlash.startsWith(isEndWithStar ? leadingPath.substr(0, leadingPath.length - 1) : leadingPath);
 			let isMatchedLeadingPath = false;
@@ -90,17 +90,16 @@ export class OpenFileFromText {
 				}
 			}
 			if (isMatchedLeadingPath) {
-				let mappedPath = this.trimPathSeparator(leadingPathMapping[leadingPath]);
+				let mappedPath = this.trimPathSeparator(leadingPathMapping[leadingPaths[i]]);
 				let remainPath = tempInputPathWithoutLeadingSlash.substr(lengthOfMatch);	// cut the match to leadingPath
 				if (mappedPath == '')	// delete folder levels
 					remainPath = this.trimPathSeparator(remainPath);
 				else if (isEndWithStar)
 					mappedPath = mappedPath.replace('*', stringStarExpandTo);	// expand a '*' if it exists.
 				let newPath = (isSlashAbsolutePath ? '/' : '') + mappedPath + remainPath;		// remainPath must either be empty or start with '/', as checked above
-				if (newPath === '') {
-					return null;		// improvement: if whole path is translated to empty string (may be deletion), such as "$variable" for leadingPathMapping = { "$*": "" }, it is better not translated.
+				if (newPath !== '') {
+					return newPath;		// improvement: if whole path is translated to empty string (may be deletion), such as "$variable" for leadingPathMapping = { "$*": "" }, it is better not accepted for this case to translated.  But continue the search.
 				}
-				return newPath;
 			}
 		}
 		return null;

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -12,15 +12,15 @@ var trueCasePathSync = require('true-case-path');
 
 
 export class OpenFileFromText {
-	private m_currFile: vscode.Uri;
+	// private m_currFile: vscode.Uri;	// Just use this.editor.document.uri.  vscode.TextEditor's document will never be null.
 
 	public constructor(private editor: vscode.TextEditor,
 		private configHandler: ConfigHandler) {
-		if (editor &&
+		/* if (editor &&
 			editor.document &&
 			editor.document.uri) {
 			this.m_currFile = editor.document.uri;
-		}
+		} */
 	}
 
 	public onChangeEditor() {
@@ -44,7 +44,7 @@ export class OpenFileFromText {
 					console.log("Execute command", word + ': Path found:', path);
 				}).catch(error => {
 					console.log("Execute command", word + ':', error);
-					if (!isOpeningMultipleFiles && ConfigHandler.Instance.Configuration.NotFoundTriggerQuickOpen) {
+					if (!isOpeningMultipleFiles && this.configHandler.Configuration.NotFoundTriggerQuickOpen) {
 						// Note it is safe below to cut prefix '/' to make the absolute path relative, because if it is an absolute path and file exists, it should have opened directly.
 						vscode.commands.executeCommand(
 							'workbench.action.quickOpen',
@@ -64,7 +64,7 @@ export class OpenFileFromText {
 
 	public rewritePathWithLeadingPathMapping(inputPath: string, isSlashAbsolutePath : boolean) : string {
 		let tempInputPathWithoutLeadingSlash = isSlashAbsolutePath ? inputPath.substr(1) : inputPath;	// for temporary match with leadingPaths only
-		let leadingPathMapping = ConfigHandler.Instance.Configuration.LeadingPathMapping;
+		let leadingPathMapping = this.configHandler.Configuration.LeadingPathMapping;
 		let leadingPaths = Object.keys(leadingPathMapping);
 		let i = leadingPaths.length;
 		for (; i-- > 0; ) {	    // need to loop backward
@@ -137,7 +137,7 @@ export class OpenFileFromText {
 
 		let isHomePath = inputPath[0] === "~";
 		let tryWorkspaceHomePath = false;
-		if (isHomePath && ConfigHandler.Instance.Configuration.LookupTildePathAlsoFromWorkspace)
+		if (isHomePath && this.configHandler.Configuration.LookupTildePathAlsoFromWorkspace)
 			tryWorkspaceHomePath = true;
 		if ( (isHomePath && !tryWorkspaceHomePath) ||
 				(isAbsolutePath && !isSlashAbsolutePath) ) { // only relative path (or absolute path start with single slash/backslash, not C: drive) can continue to lookup from other folders
@@ -159,7 +159,7 @@ export class OpenFileFromText {
 			let extraExtensions = [];
 			if (assumeExtWithoutDot in extensionsMap && isArray(extensionsMap[assumeExtWithoutDot]))
 				extraExtensions = [...extensionsMap[assumeExtWithoutDot]];
-			extensions = this.mergeDeduplicate(extensions, extraExtensions, ConfigHandler.Instance.Configuration.Extensions);
+			extensions = this.mergeDeduplicate(extensions, extraExtensions, this.configHandler.Configuration.Extensions);
 		}
 
 		// Find which workspace folder current editing document is in.  only lookup parents folders if isWithinAWorkspaceFolder

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -46,9 +46,10 @@ export class OpenFileFromText {
 					console.log("Execute command", word + ':', error);
 					if (!isOpeningMultipleFiles && this.configHandler.Configuration.NotFoundTriggerQuickOpen) {
 						// Note it is safe below to cut prefix '/' to make the absolute path relative, because if it is an absolute path and file exists, it should have opened directly.
+						let newWord = this.rewritePathWithLeadingPathMapping(word.replace(/\\/g, '/'), !!word.match(/^[\/\\][^\/\\]/));
 						vscode.commands.executeCommand(
 							'workbench.action.quickOpen',
-							this.trimPathSeparator(word) 	// trim / and \ from both ends of file string
+							this.trimPathSeparator(newWord) 	// trim / and \ from both ends of file string
 						);
 					}
 				});

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -49,7 +49,7 @@ export class OpenFileFromText {
 						let newWord = this.rewritePathWithLeadingPathMapping(word.replace(/\\/g, '/'), !!word.match(/^[\/\\][^\/\\]/));
 						vscode.commands.executeCommand(
 							'workbench.action.quickOpen',
-							this.trimPathSeparator(newWord) 	// trim / and \ from both ends of file string
+							this.trimPathSeparator(newWord !== null ? newWord : word) 	// trim / and \ from both ends of file string
 						);
 					}
 				});

--- a/src/commands/openFileFromText.ts
+++ b/src/commands/openFileFromText.ts
@@ -97,6 +97,9 @@ export class OpenFileFromText {
 				else if (isEndWithStar)
 					mappedPath = mappedPath.replace('*', stringStarExpandTo);	// expand a '*' if it exists.
 				let newPath = (isSlashAbsolutePath ? '/' : '') + mappedPath + remainPath;		// remainPath must either be empty or start with '/', as checked above
+				if (newPath === '') {
+					return null;		// improvement: if whole path is translated to empty string (may be deletion), such as "$variable" for leadingPathMapping = { "$*": "" }, it is better not translated.
+				}
 				return newPath;
 			}
 		}

--- a/src/common/textoperations.ts
+++ b/src/common/textoperations.ts
@@ -5,6 +5,7 @@ import { ConfigHandler } from '../configuration/confighandler';
 
 export class TextOperations
 {
+	/** @deprecated.  Now can use document.lineAt() in OpenFileFromText#getWordRanges. */
 	public static getCurrentLine(iText: string, iLine: number): string
 	{
 		if( iText === undefined || iText === "" )

--- a/test/common/fileoperations.test.ts
+++ b/test/common/fileoperations.test.ts
@@ -254,9 +254,14 @@ suite("File operation Tests", () => {
 		assert.equal(res, "d:\\Temp\\test\\dir1\\testcase2.ts");
 	});
 	test("resolvePath, resolve path with path substitution, using prefix match with ending '*', by leadingPathMapping's deletion, removing path's leading variable", () => {
-		ConfigHandler.Instance.Configuration.LeadingPathMapping = { "$*": "" };
+		ConfigHandler.Instance.Configuration.LeadingPathMapping = { "$*": "*", "$*?": "" };		// "$*?" is a special case, same as "$*", but for non-duplicated keys
 		let res = openFile.resolvePath("$basePath/test/dir1/testcase2", "d:/Temp/src/Class1.ts");
 		assert.equal(res, "d:\\Temp\\test\\dir1\\testcase2.ts");
+	});
+	test("resolvePath, resolve path with path substitution, using prefix match with ending '*', by leadingPathMapping, removing '$' for single variable", () => {
+		ConfigHandler.Instance.Configuration.LeadingPathMapping = { "$*": "*", "$*?": "" };		// "$*?" is a special case, same as "$*", but for non-duplicated keys. Later value in this leadingPathMapping has higher priority.  E.g. such that { "abc": "...", "abc/def": "..." } works better in natural order
+		let res = openFile.resolvePath("$class1", "d:/Temp/test/dir1/testcase2.ts");
+		assert.equal(res, "d:\\Temp\\src\\Class1.ts");
 	});
 
 	test("A multi-lined selection should split, and support cutting :content from lines of grep/ack output like file:line:column:content", (done) => {

--- a/test/common/fileoperations.test.ts
+++ b/test/common/fileoperations.test.ts
@@ -253,6 +253,11 @@ suite("File operation Tests", () => {
 		let res = openFile.resolvePath("$test/dir1/testcase2", "d:/Temp/test.ts");
 		assert.equal(res, "d:\\Temp\\test\\dir1\\testcase2.ts");
 	});
+	test("resolvePath, resolve path with path substitution, using prefix match with ending '*', by leadingPathMapping's deletion, removing path's leading variable", () => {
+		ConfigHandler.Instance.Configuration.LeadingPathMapping = { "$*": "" };
+		let res = openFile.resolvePath("$basePath/test/dir1/testcase2", "d:/Temp/src/Class1.ts");
+		assert.equal(res, "d:\\Temp\\test\\dir1\\testcase2.ts");
+	});
 
 	test("A multi-lined selection should split, and support cutting :content from lines of grep/ack output like file:line:column:content", (done) => {
 		let line1 = 'd:/Temp/test/testcase.txt:4:3:the forth line\n';


### PR DESCRIPTION
Add '?' and '{}' as path delimiters for some common cases:
- '?' for openning file from partial url may contain query string file.php?a=1&...
- '{}' is commonly used to delimit template variables or program variables (bash, PHP, Ruby, etc), like "{$url_path}/file.php".

Besides:  I could think of '\`' which may be considered too, but seems to me not as common as the aboves.  E.g. new Javascript use \`...\` as template string literal.  Thus not in my pull request, but up to you.  :)